### PR TITLE
make-sprint: add verbose options printout

### DIFF
--- a/lib/make-sprint.js
+++ b/lib/make-sprint.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var debug = require('./debug')('make-sprint');
 var fmt = require('util').format;
 var genMilestones = require('strong-github-api').milestoneGenerator;
@@ -66,6 +67,8 @@ exports.handler = function(argv, options) {
   return genMilestones(opts).then(function(msgs) {
     if (argv.verbose) {
       _console.log(msgs.join(os.EOL));
+      _console.log('Properties used for milestone: %s',
+        inspect(_.omit(opts, 'octo', 'password', 'token', 'console')));
     }
     _console.log(
         fmt('Complete! Created milestones for %s repositories', msgs.length));


### PR DESCRIPTION
Print out the options when using the verbose feature (omitting
some sensitive values).