### PR TITLE
make-sprint: use an ISO 8601 due date, not days

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For a complete list of options, run `sl-gh make-sprint --help`.
 
 ### Example
 ```
-sl-gh make-sprint 14 --token=abcdef12345abcdef12345 --org=strongloop --title="Sprint 42"
+sl-gh make-sprint 2012-12-12 --token=abcdef12345abcdef12345 --org=strongloop --title="Sprint 42"
 --description="Sprint to end all sprints!"
 ```
 

--- a/lib/make-sprint.js
+++ b/lib/make-sprint.js
@@ -9,8 +9,9 @@ var moment = require('moment');
 var os = require('os');
 var util = require('./util');
 
-exports.command = 'make-sprint <days> [options..]';
-exports.describe = 'Automatically create a milestone for a list of repos.';
+exports.command = 'make-sprint <due_date> [options..]';
+exports.describe = fmt('Automatically create a milestone for a list of repos.',
+  'Use an ISO 8601 date for your <date> parameter.');
 
 exports.builder = function(yargs) {
   return yargs.option('user', {
@@ -56,7 +57,7 @@ exports.handler = function(argv, options) {
   opts.user = argv.user;
   opts.org = argv.org;
   opts.octo = octo;
-  opts.due_on = moment().add(argv.days, 'days').toISOString();
+  opts.due_on = moment(argv.due_date).toISOString();
   opts.title = argv.title || 'Sprint ' + opts.due_on;
   opts.description = argv.description ||
     'Created by strong-github-analytics!';


### PR DESCRIPTION
Switch to using an explicit datetime value, rather than asking the
user to input the number of days for the milestone marker(s).