### PR TITLE
make-sprint: enable useList functionality

### DIFF
--- a/lib/make-sprint.js
+++ b/lib/make-sprint.js
@@ -40,6 +40,10 @@ exports.builder = function(yargs) {
     describe: 'Provide details about each repository\'s milestone operation.',
   }).option('dryrun', {
     describe: 'Simulate the run; do not create the milestones',
+  }).option('useList', {
+    alias: 'l',
+    describe: fmt('Path to a JSON file with target repositories.',
+    'Use this to avoid automatically scanning orgs/users.'),
   });
 };
 
@@ -57,12 +61,13 @@ exports.handler = function(argv, options) {
   opts.user = argv.user;
   opts.org = argv.org;
   opts.octo = octo;
-  opts.due_on = moment(argv.due_date).toISOString();
-  opts.title = argv.title || 'Sprint ' + opts.due_on;
+  opts.dueOn = moment(argv.due_date).toISOString();
+  opts.title = argv.title || 'Sprint ' + opts.dueOn;
   opts.description = argv.description ||
     'Created by strong-github-analytics!';
   opts.verbose = argv.verbose;
   opts.dryrun = argv.dryrun;
+  opts.list = argv.useList;
   debug('options: %s', inspect(opts));
   _console.log('Generating milestones...');
   return genMilestones(opts).then(function(msgs) {


### PR DESCRIPTION
strong-github-api now allows us to provide a list of repositories
to create milestones for, rather than scanning an org/user.